### PR TITLE
Prevent compilation failure due to digraph.

### DIFF
--- a/examples/cxx-api.cxx
+++ b/examples/cxx-api.cxx
@@ -53,9 +53,9 @@ Replxx::hints_t hook_hint(std::string const& context, int index, Replxx::Color& 
 
 int real_len( std::string const& s ) {
 	int len( 0 );
-	char m4( 128 + 64 + 32 + 16 );
-	char m3( 128 + 64 + 32 );
-	char m2( 128 + 64 );
+	unsigned char m4( 128 + 64 + 32 + 16 );
+	unsigned char m3( 128 + 64 + 32 );
+	unsigned char m2( 128 + 64 );
 	for ( int i( 0 ); i < static_cast<int>( s.length() ); ++ i, ++ len ) {
 		char c( s[i] );
 		if ( ( c & m4 ) == m4 ) {

--- a/src/replxx.cxx
+++ b/src/replxx.cxx
@@ -561,7 +561,7 @@ int Replxx::print( char const* format_, ... ) {
 }
 
 ::Replxx* replxx_init() {
-	return ( reinterpret_cast<::Replxx*>( new replxx::Replxx::ReplxxImpl( nullptr, nullptr, nullptr ) ) );
+	return ( reinterpret_cast< ::Replxx*>( new replxx::Replxx::ReplxxImpl( nullptr, nullptr, nullptr ) ) );
 }
 
 void replxx_end( ::Replxx* replxx_ ) {


### PR DESCRIPTION
The character sequence <: was mistakenly interpreted as a digraph by some older C++ compilers.
I simply inserted a space between the < and the :: in a reinterpret cast, to prevent compilation failure on older compilers.